### PR TITLE
added check for self. Fixed '10240' issue when running the module locally

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ glob(path.join(cwd, "node_modules", ".bin", "*"), function (err, files) {
     if (!stat.isFile()) {
       return;
     }
+    if (file.indexOf('increase-memory-limit') >= 0) {
+      return;
+    }
     let contents = fs.readFileSync(file).toString();
     let lines = contents.split('\n')
 


### PR DESCRIPTION
When running the module locally through the npm script, it throws a 10240:
![image](https://user-images.githubusercontent.com/3444220/30610998-f08cbd0a-9d34-11e7-8e30-259cd3d0ead8.png)

I think this is because it tries to access itself, but fails to do so. I added a conditional to check whether it contains its own name or not.