### PR TITLE
Fix: typo in variable naming

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const glob = require('glob');
 const fs = require('fs');
 
-const maxOldSpaceSice = process.env.LIMIT || 10240;
+const maxOldSpaceSize = process.env.LIMIT || 10240;
 const cwd = process.cwd() + path.sep;
 
 glob(path.join(cwd, "node_modules", ".bin", "*"), function (err, files) {
@@ -32,7 +32,7 @@ glob(path.join(cwd, "node_modules", ".bin", "*"), function (err, files) {
       if (line.startsWith("if [") || line.startsWith("@IF")) {
         patchedContents += line + "\n";
       } else {
-        patchedContents += line.replace(/node(\.exe)?\b(?: \-\-max\-old\-space\-size\=[0-9]+)?/, `node$1 --max-old-space-size=${maxOldSpaceSice}`) + "\n";
+        patchedContents += line.replace(/node(\.exe)?\b(?: \-\-max\-old\-space\-size\=[0-9]+)?/, `node$1 --max-old-space-size=${maxOldSpaceSize}`) + "\n";
       }
     }
 


### PR DESCRIPTION
`maxOldSpaceSice` -> `maxOldSpaceSize`